### PR TITLE
Fix default print direction

### DIFF
--- a/src/main/java/com/github/dtmo/jfiglet/FigFont.java
+++ b/src/main/java/com/github/dtmo/jfiglet/FigFont.java
@@ -508,7 +508,7 @@ public class FigFont {
 		/**
 		 * The direction the font is to be printed by default.
 		 */
-		private PrintDirection printDirection;
+		private PrintDirection printDirection = PrintDirection.LEFT_TO_RIGHT;
 
 		private int fullLayout;
 

--- a/src/test/java/com/github/dtmo/jfiglet/FigFontReaderTest.java
+++ b/src/test/java/com/github/dtmo/jfiglet/FigFontReaderTest.java
@@ -13,7 +13,7 @@ public class FigFontReaderTest {
 	public void testParseHeader() {
 		FigFont.Builder fontBuilder = new FigFont.Builder();
 
-		FigFontReader.parseHeader("flf2a$ 6 5 16 15 11 0 24463 229", fontBuilder);
+		FigFontReader.parseHeader("flf2a$ 6 5 16 15 11 1 24463 229", fontBuilder);
 
 		assertEquals('$', fontBuilder.getHardBlankChar());
 		assertEquals(6, fontBuilder.getHeight());
@@ -21,8 +21,26 @@ public class FigFontReaderTest {
 		assertEquals(16, fontBuilder.getMaxLength());
 		assertEquals(15, fontBuilder.getOldLayout());
 		assertEquals(11, fontBuilder.getCommentLines());
-		assertEquals(FigFont.PrintDirection.LEFT_TO_RIGHT, fontBuilder.getPrintDirection());
+		assertEquals(FigFont.PrintDirection.RIGHT_TO_LEFT, fontBuilder.getPrintDirection());
 		assertEquals(24463, fontBuilder.getFullLayout());
 		assertEquals(229, fontBuilder.getCodetagCount());
 	}
+
+	@Test
+	public void testDefaultHeaderValues() {
+		FigFont.Builder fontBuilder = new FigFont.Builder();
+
+		FigFontReader.parseHeader("flf2a$ 5 4 20 11 1", fontBuilder);
+
+		assertEquals('$', fontBuilder.getHardBlankChar());
+		assertEquals(5, fontBuilder.getHeight());
+		assertEquals(4, fontBuilder.getBaseline());
+		assertEquals(20, fontBuilder.getMaxLength());
+		assertEquals(11, fontBuilder.getOldLayout());
+		assertEquals(1, fontBuilder.getCommentLines());
+		assertEquals(FigFont.PrintDirection.LEFT_TO_RIGHT, fontBuilder.getPrintDirection());
+		assertEquals(11, fontBuilder.getFullLayout());
+		assertEquals(0, fontBuilder.getCodetagCount());
+	}
+
 }


### PR DESCRIPTION
Fonts that do not have the print direction set in the header values are rendered right-to-left instead of left-to-right.

This fixes issue #1.